### PR TITLE
Fix back camera orientation

### DIFF
--- a/Examples/Extras/WebRTC_patches/orientation.patch
+++ b/Examples/Extras/WebRTC_patches/orientation.patch
@@ -19,14 +19,12 @@ index 49b5681..dcafaec 100644
        _rotation = webrtc::kVideoRotation_270;
        break;
      case UIDeviceOrientationLandscapeLeft:
-+      orientation = _capturer->GetUseBackCamera() ? AVCaptureVideoOrientationLandscapeLeft
-+                                                : AVCaptureVideoOrientationLandscapeRight;
++       orientation = AVCaptureVideoOrientationLandscapeRight;                                                                       
        _rotation = _capturer->GetUseBackCamera() ? webrtc::kVideoRotation_0
                                                  : webrtc::kVideoRotation_180;
        break;
      case UIDeviceOrientationLandscapeRight:
-+      orientation = _capturer->GetUseBackCamera() ? AVCaptureVideoOrientationLandscapeRight
-+                                              : AVCaptureVideoOrientationLandscapeLeft;
++		orientation =  AVCaptureVideoOrientationLandscapeLeft;                                      
        _rotation = _capturer->GetUseBackCamera() ? webrtc::kVideoRotation_180
                                                  : webrtc::kVideoRotation_0;
        break;


### PR DESCRIPTION
Select the right orientation setting when using the back camera on iOS.  Video on the remote side appeared upside down when in landscape left and landscape right.  